### PR TITLE
concepts: add environment variable name

### DIFF
--- a/doc/concepts/secrets_variables.md
+++ b/doc/concepts/secrets_variables.md
@@ -98,7 +98,8 @@ runs:
       - ...
       - name: build docker image
         environment:
-          from_variable: dockerpassword
+          DOCKERAUTH:
+            from_variable: dockerpassword
         steps:
          # Steps to build and push the docker image
          - ...


### PR DESCRIPTION
In the example, to assign the "dockerpassword" variable value to an environment variable for the task, we need to specify a variable name. Otherwise "from_variable" will be the name and "dockerpassword" the value.