### PR TITLE
home: add forum link

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,11 @@ actionLink: /tryit/
   text-align: center;
 }
 
-.githubbutton {
+.roundedbutton {
   position: relative;
   display: inline-block;
   margin: 0 2em;
+  margin-top: 1em;
   font-size: 1.05em;
   font-weight: 600;
   letter-spacing: 0.1em;
@@ -43,7 +44,7 @@ actionLink: /tryit/
   text-indent: 1.4em;
 }
 
-.githubbutton svg {
+.roundedbutton svg {
   position: absolute;
   left: 0.4em;
   top: 0.4em;
@@ -52,12 +53,18 @@ actionLink: /tryit/
 </style>
 
 <div class="center">
-  <a class="githubbutton" href="https://github.com/agola-io/agola" target="_blank">
+  <a class="roundedbutton" href="https://github.com/agola-io/agola" target="_blank">
     <svg aria-labelledby="simpleicons-github-dark-icon" lang="" role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
       <title id="simpleicons-github-icon" lang="en">GitHub Dark icon</title>
       <path fill="#7F8C8D" d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"></path>
     </svg>
     GITHUB
+  </a>
+  <a class="roundedbutton" href="https://talk.agola.io" target="_blank">
+    <svg lang="" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 299.99 299.99">
+        <path fill="#7F8C8D" d="M149.995,0C67.158,0,0,67.156,0,149.995S67.158,299.99,149.995,299.99c82.839,0,149.995-67.156,149.995-149.995 S232.834,0,149.995,0z M89.481,211.219l-37.176,9.959l10.177-37.973c-7.01-12.05-11.051-26.05-11.051-40.997 c0-45.074,36.541-81.618,81.62-81.618c45.071,0,81.615,36.544,81.615,81.618c0,45.074-36.544,81.62-81.615,81.62 C117.023,223.832,102.091,219.199,89.481,211.219z M247.76,236.976l-33.818-9.059c-11.477,7.257-25.057,11.474-39.63,11.474 c-10.39,0-20.271-2.142-29.248-5.999c45.064-5.9,79.981-44.527,79.981-91.177c0-13.518-2.959-26.351-8.216-37.926 c19.182,13.427,31.73,35.67,31.73,60.853c0,13.596-3.673,26.33-10.05,37.293L247.76,236.976z"/>
+    </svg>
+    FORUM
   </a>
 </div>
 


### PR DESCRIPTION
It would be useful to have, on the agola.io home page, a link to the forum on "talk.agola.io".
This is a try to add the forum link beside the github one:

![screenshot](https://user-images.githubusercontent.com/5462153/64908589-7be4a800-d702-11e9-8c42-23acea439187.jpg)


